### PR TITLE
fix: uploading more than one file in a row now works

### DIFF
--- a/frontend/store/addresses/reducer.js
+++ b/frontend/store/addresses/reducer.js
@@ -35,6 +35,7 @@ function addressesReducer(state = {}, {type, payload}) {
     case 'COMPLETED_PROCESSING_FILE':
       return {
         ...state,
+        readyToUpload: [],
         processing: {
           ...state.processing,
           errorsProcessing: !payload.successful,


### PR DESCRIPTION
Uploading a second file attempted to reupload all previously processed data. This clears the array of processed data each time an upload occurs so we aren't submitting duplicate records to the database.